### PR TITLE
Specify web process type to Heroku Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-bundle exec puma -C config/puma.rb
+web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
Add missing web process type specification to Procfile for Heroku's HTTP routing stack
